### PR TITLE
Placeholder was now empty

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -268,7 +268,8 @@ def get_url(uid):
 
 selfClosingTags = ('br', 'hr', 'nobr', 'ref', 'references', 'nowiki')
 
-placeholder_tags = {'math': 'formula', 'code': 'codice'}
+#placeholder_tags = {'math': 'formula', 'code': 'codice'}
+placeholder_tags = {}
 
 
 def normalizeTitle(title):


### PR DESCRIPTION
Placeholder with math and code is now empty because information in this tag was loose. There only string 'codice_5' but text is missing.